### PR TITLE
Bug Fix: Fix iOS Facebook Login & add support for Facebook Deep Linking + improve attribution for Apple Search Ads

### DIFF
--- a/ios/flutter_branch_sdk.podspec
+++ b/ios/flutter_branch_sdk.podspec
@@ -15,6 +15,7 @@ Flutter Plugin for Brach Metrics SDK - https:&#x2F;&#x2F;branch.io
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.dependency 'FBSDKCoreKit', '~> 5.5'
   s.dependency 'Branch', '~> 0.31.3'
   s.platform = :ios, '8.0'
 


### PR DESCRIPTION
Hi @RodrigoSMarques ,

Copied below from previous PR:

Correct, it does not work with the Facebook Login. Facebook tries to call the URL scheme fb[appId]://authorize after login but branch does not handle this URL scheme correctly so the app does not get opened. I added a fix for this on Line 65 in SwiftFlutterBranchSdkPlugin.swift.

I added two other features as well.

To allow deeplinks from Facebook to work appropriately [1] and improve attribution for people using branch links on Apple Search Ads [2].

[1]: https://help.branch.io/using-branch/docs/facebook-app-install-ads (see registerFacebookDeepLinkingClass method)
[2]: https://help.branch.io/developers-hub/docs/ios-advanced-features#section-track-apple-search-ads

Best,
Mark