### PR TITLE
fix: if not handled by branch, return false

### DIFF
--- a/ios/Classes/SwiftFlutterBranchSdkPlugin.swift
+++ b/ios/Classes/SwiftFlutterBranchSdkPlugin.swift
@@ -56,13 +56,13 @@ public class SwiftFlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStream
     }
     
     public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        Branch.getInstance().application(app, open: url, options: options)
-        return true
+        let branchHandled = Branch.getInstance().application(app, open: url, options: options)
+        return branchHandled
     }
     
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
-        Branch.getInstance().continue(userActivity)
-        return true
+        let handledByBranch = Branch.getInstance().continue(userActivity)
+        return handledByBranch
     }
     
     public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {


### PR DESCRIPTION
If url is not handled by Branch, return false. This pr fix facebook login, kakao login, and other deeplink services. https://github.com/RodrigoSMarques/flutter_branch_sdk/pull/16 is only happens when using native app, webview is ok.

https://github.com/BranchMetrics/ios-branch-deep-linking-attribution#swift-2

> ```swift
> func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
>     // Pass the url to the handle deep link call
>     let branchHandled = Branch.getInstance().application(
>         application,
>         open: url,
>         options: options
>     )
>     if (!branchHandled) {
>         // If not handled by Branch, do other deep link routing for the
>         // Facebook SDK, Pinterest SDK, etc
>     }
>     return true
> }
> 
> func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
>     let handledByBranch = Branch.getInstance().continue(userActivity)
>     return handledByBranch
> }
> ```

