### PR TITLE
Cast error due to missing parameters

### DIFF
--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
@@ -620,14 +620,20 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
         if (argsMap.containsKey("expirationDate"))
             buo.setContentExpiration((Date) argsMap.get("expirationDate"));
         if (argsMap.containsKey("locallyIndex")) {
-            boolean value = (boolean) argsMap.get("locallyIndex");
+            boolean value = false;
+            if (argsMap.get("locallyIndex") != null){
+                value = (boolean) argsMap.get("locallyIndex");
+            }
             if (value) {
                 buo.setLocalIndexMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC);
             } else
                 buo.setLocalIndexMode(BranchUniversalObject.CONTENT_INDEX_MODE.PRIVATE);
         }
         if (argsMap.containsKey("publiclyIndex")) {
-            boolean value = (boolean) argsMap.get("publiclyIndex");
+            boolean value = false;
+            if (argsMap.get("publiclyIndex") != null){
+                value = (boolean) argsMap.get("publiclyIndex");
+            }
             if (value) {
                 buo.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC);
             } else


### PR DESCRIPTION
Found that if these parameters aren't being set it can cause the application to crash when generating a link. I think we can assume if the dev doesn't set this parameter then we default to false. It's also a good idea be type checking before casting generic objects

Here's the stacktrace of the error I'm aiming to fix:

```
E/MethodChannel#flutter_branch_sdk/message( 8094): Failed to handle method call
E/MethodChannel#flutter_branch_sdk/message( 8094): java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at br.com.rsmarques.flutter_branch_sdk.FlutterBranchSdkPlugin.convertToBUO(FlutterBranchSdkPlugin.java:623)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at br.com.rsmarques.flutter_branch_sdk.FlutterBranchSdkPlugin.getShortUrl(FlutterBranchSdkPlugin.java:311)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at br.com.rsmarques.flutter_branch_sdk.FlutterBranchSdkPlugin.onMethodCall(FlutterBranchSdkPlugin.java:218)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:231)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:93)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:642)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at android.os.MessageQueue.next(MessageQueue.java:336)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at android.os.Looper.loop(Looper.java:174)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at android.app.ActivityThread.main(ActivityThread.java:7356)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
E/MethodChannel#flutter_branch_sdk/message( 8094): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
I/flutter ( 8094): Share error : PlatformException(error, Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference, null)
```
