### PR TITLE
Use data_parsed field rather than data field when init on web

### DIFF
--- a/lib/src/flutter_branch_sdk_web.dart
+++ b/lib/src/flutter_branch_sdk_web.dart
@@ -171,8 +171,8 @@ class FlutterBranchSdk extends FlutterBranchSdkPlatform {
       if (err == null) {
         if (data != null) {
           var parsedData = _jsObjectToDartObject(data);
-          if (parsedData is Map && parsedData.containsKey("data")) {
-            parsedData = parsedData["data"];
+          if (parsedData is Map && parsedData.containsKey("data_parsed")) {
+            parsedData = parsedData["data_parsed"];
           }
           if (parsedData is String) {
             try {


### PR DESCRIPTION
The `data` field can be an empty string.

Therefore sometimes `Failed to try to parse JSON: FormatException: SyntaxError: Unexpected end of JSON input - ` is printed.

Have changed to use `data_parsed` field rather than `data` field when init on web