### PR TITLE
[BugFix: Force convert null to String via as! will cause iOS project …

### DIFF
--- a/ios/Classes/FlutterBranchIoSdkHelper.swift
+++ b/ios/Classes/FlutterBranchIoSdkHelper.swift
@@ -191,7 +191,7 @@ func convertToEvent(dict: [String: Any?]) -> BranchEvent? {
     }
     if let dictCustomData = dict["customData"] as? [String: Any] {
         for customData in dictCustomData {
-            event.customData[customData.key] = (customData.value  as! String)
+            event.customData[customData.key] = (customData.value  as? String)
         }
     }
     return event


### PR DESCRIPTION
BugFix: as! may cause error "Could not cast value of type 'NSNull' (0x27328cf28) to 'NSString' (0x27329a290)." and stuck the app when init branchio SDK.
