### PR TITLE
Fix crash when adding a boolean control param

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,18 +23,18 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+**Smartphone (Please complete the following information. remove session if not platform):**
+ - Flutter: version: [e.g. 2.2.3]
+ - Package version: [e.g. 3.3.0]
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+
+**Web (Please complete the following information. remove session if not platform)):**
  - Flutter: version: [e.g. 2.2.3]
  - Package version: [e.g. 3.3.0]
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Flutter: version: [e.g. 2.2.3]
- - Package version: [e.g. 3.3.0]
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
 
 **Additional context**
 Add any other context about the problem here.

--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkHelper.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkHelper.java
@@ -161,8 +161,8 @@ public class FlutterBranchSdkHelper {
             }
         }
         if (argsMap.containsKey("controlParams")) {
-            for (Map.Entry<String, String> content : ((HashMap<String, String>) argsMap.get("controlParams")).entrySet()) {
-                linkProperties.addControlParameter(content.getKey(), content.getValue());
+            for (Map.Entry<String, Object> content : ((HashMap<String, Object>) argsMap.get("controlParams")).entrySet()) {
+                linkProperties.addControlParameter(content.getKey(), content.getValue().toString());
             }
         }
         return linkProperties;


### PR DESCRIPTION
I am using `ios_nativelink` as boolean, [as probably it is supposed to be used](https://help.branch.io/using-branch/docs/creating-a-deep-link#deep-linking) and it is working great on iOS but it is crashing on Android with the following `java.lang.Boolean cannot be cast to java.lang.String`

```
_Exception (Exception: PlatformException(error, java.lang.Boolean cannot be cast to java.lang.String, null, java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
  at br.com.rsmarques.flutter_branch_sdk.FlutterBranchSdkHelper.convertToLinkProperties(FlutterBranchSdkHelper.java:165)
  at br.com.rsmarques.flutter_branch_sdk.FlutterBranchSdkPlugin.showShareSheet(FlutterBranchSdkPlugin.java:383)
  at br.com.rsmarques.flutter_branch_sdk.FlutterBranchSdkPlugin.onMethodCall(FlutterBranchSdkPlugin.java:241)
  at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:262)
  at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:295)
  at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$DartMessenger(DartMessenger.java:319)
  at io.flutter.embedding.engine.dart.-$$Lambda$DartMessenger$AIEPqY6mWzaNK15HekX9bftoAXs.run(Unknown Source:12)
  at android.os.Handler.handleCallback(Handler.java:938)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at android.os.Looper.loop(Looper.java:255)
  at android.app.ActivityThread.main(ActivityThread.java:8224)
  at java.lang.reflect.Method.invoke(Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)
```

So I changed `Map.Entry<String, String> content` to `Map.Entry<String, Object> content` for `controlParams` as for `customMetadata`