### PR TITLE
Release 8.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 8.0.4
+### ⚠️ BREAKING CHANGE
+This is a major release which contains breaking API changes.
+#### ⚠️ SDK Initialization Changed
+* `useTestKey` parameter is no longer supported at `FlutterBranchSdk.init()`.
+
+Check the instructions in `README.MD` on how to activate the `key_test_`.
+
+### 🐛 Bug Fixes
+* Fix issue #347: ios plugin v8.0.3 crashes when no url is returned
+* Fix issue #338: Changing the return value in didFinishLaunchingWithOptions crashes the application from SDK version above 8.0.0
+
 ## 8.0.3
 ### ⚠️ BREAKING CHANGE
 This is a major release which contains breaking API changes.

--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
@@ -466,7 +466,7 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
             @Override
             public void onLinkCreate(String url, BranchError error) {
 
-                if ((error == null) || (error != null && url != null)) {
+                if ((error == null && url != null) || (error != null && url != null)) {
                     LogUtils.debug(DEBUG_NAME, "Branch link to share: " + url);
                     response.put("success", true);
                     response.put("url", url);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "8.0.2"
+    version: "8.0.4"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/Classes/SwiftFlutterBranchSdkPlugin.swift
+++ b/ios/Classes/SwiftFlutterBranchSdkPlugin.swift
@@ -47,14 +47,13 @@ public class SwiftFlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStream
     }
     
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
-        branch = Branch.getInstance();
-        branch!.registerPluginName(PLUGIN_NAME, version:  getPluginVersion())
+        Branch.getInstance().registerPluginName(PLUGIN_NAME, version:  getPluginVersion())
 
         if #available(iOS 15.0, *) {
-            branch!.checkPasteboardOnInstall()
+            Branch.getInstance().checkPasteboardOnInstall()
         }
 
-        branch!.initSession(launchOptions: launchOptions) { (params, error) in
+        Branch.getInstance().initSession(launchOptions: launchOptions) { (params, error) in
             if error == nil {
                 print("Branch InitSession params: \(String(describing: params as? [String: Any]))")
                 guard let _ = self.eventSink else {
@@ -78,22 +77,22 @@ public class SwiftFlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStream
     }
     
     public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        let branchHandled = branch!.application(app, open: url, options: options)
+        let branchHandled = Branch.getInstance().application(app, open: url, options: options)
         return branchHandled
     }
     
     public func application(_ app: UIApplication, open url: URL, sourceApplication: String, annotation: Any) -> Bool {
-        let branchHandled = branch!.application(app, open: url, sourceApplication: sourceApplication, annotation: annotation)
+        let branchHandled = Branch.getInstance().application(app, open: url, sourceApplication: sourceApplication, annotation: annotation)
         return branchHandled
     }
     
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
-        let handledByBranch = branch!.continue(userActivity)
+        let handledByBranch = Branch.getInstance().continue(userActivity)
         return handledByBranch
     }
     
     public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
-        branch!.handlePushNotification(userInfo)
+        Branch.getInstance().handlePushNotification(userInfo)
     }
     
     //---------------------------------------------------------------------------------------------
@@ -260,17 +259,17 @@ public class SwiftFlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStream
         
         if (!requestMetadata.isEmpty) {
             for param in requestMetadata {
-                branch!.setRequestMetadataKey(param.key, value: param.value)
+                Branch.getInstance().setRequestMetadataKey(param.key, value: param.value)
             }
         }
         if (!snapParameters.isEmpty) {
             for param in snapParameters {
-                branch!.addSnapPartnerParameter(withName: param.key, value: param.value)
+                Branch.getInstance().addSnapPartnerParameter(withName: param.key, value: param.value)
             }
         }
         if (!facebookParameters.isEmpty) {
             for param in facebookParameters {
-                branch!.addFacebookPartnerParameter(withName: param.key, value: param.value)
+                Branch.getInstance().addFacebookPartnerParameter(withName: param.key, value: param.value)
             }
         }
         isInitialized = true
@@ -286,7 +285,7 @@ public class SwiftFlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStream
         
         let response : NSMutableDictionary! = [:]
         buo?.getShortUrl(with: lp!) { (url, error) in
-            if ((error == nil) || (error != nil && url != nil)) {
+            if ((error == nil && url != nil) || (error != nil && url != nil)) {
                 NSLog("getShortUrl: %@", url!)
                 response["success"] = NSNumber(value: true)
                 response["url"] = url!

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -108,10 +108,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_branch_sdk
 description: Flutter Plugin for create deep link using Brach SDK (https://branch.io). This plugin provides a cross-platform (iOS, Android, Web).
-version: 8.0.3
+version: 8.0.4
 homepage: https://github.com/RodrigoSMarques/flutter_branch_sdk
 
 environment:
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.2
+  flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## 8.0.4
### ⚠️ BREAKING CHANGE
This is a major release which contains breaking API changes. #### ⚠️ SDK Initialization Changed
* `useTestKey` parameter is no longer supported at `FlutterBranchSdk.init()`.

Check the instructions in `README.MD` on how to activate the `key_test_`.

### 🐛 Bug Fixes
* Fix issue #347: ios plugin v8.0.3 crashes when no url is returned
* Fix issue #338: Changing the return value in didFinishLaunchingWithOptions crashes the application from SDK version above 8.0.0