### PR TITLE
fixed: reply already sent and a possible ANR

### DIFF
--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/MethodResultWrapper.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/MethodResultWrapper.java
@@ -9,14 +9,26 @@ import io.flutter.plugin.common.MethodChannel;
 public class MethodResultWrapper implements MethodChannel.Result {
     private final MethodChannel.Result methodResult;
     private final Handler handler;
+    private boolean called;
 
     MethodResultWrapper(MethodChannel.Result result) {
         methodResult = result;
         handler = new Handler(Looper.getMainLooper());
     }
 
+    private synchronized boolean checkNotCalled() {
+        if (called) {
+            return false;
+        }
+        called = true;
+        return true;
+    }
+
     @Override
     public void success(final Object result) {
+        if (!checkNotCalled()) {
+            return;
+        }
         handler.post(
                 new Runnable() {
                     @Override
@@ -33,6 +45,9 @@ public class MethodResultWrapper implements MethodChannel.Result {
     @Override
     public void error(
             final String errorCode, final String errorMessage, final Object errorDetails) {
+        if (!checkNotCalled()) {
+            return;
+        }
         handler.post(
                 new Runnable() {
                     @Override
@@ -48,6 +63,9 @@ public class MethodResultWrapper implements MethodChannel.Result {
 
     @Override
     public void notImplemented() {
+        if (!checkNotCalled()) {
+            return;
+        }
         handler.post(
                 new Runnable() {
                     @Override


### PR DESCRIPTION

<img width="1039" alt="Screenshot 2025-01-09 at 4 16 39 PM" src="https://github.com/user-attachments/assets/64a80fd4-0c28-45df-945b-b608091aa93f" />

It stops sending the result twice for the same method which fixes the above crash.