### PR TITLE
Release 9.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 9.3.0
+### 🔧 Native SDK Updates
+* Updated included Branch Android SDK to 5.21.0 - [Android Version History](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/releases)
+
+### 🎉 Features
+* New Method: `setInstallReferrerTimeout` - Provides a setting to cancel the external Install Referrer string fetch. This is useful to optimize performance on Android by limiting the time the SDK waits for the Install Referrer. Only applicable on Android - iOS ignores this setting.
+* Added support for `installReferrerTimeout` configuration key in `branch-config.json`. This allows you to set the Install Referrer timeout during app initialization without code changes.
+  - Configuration example: `"installReferrerTimeout": 5000` (in milliseconds)
+  - See `README.md` for full documentation
+
+### 📖 Documentation
+* Updated `README.md` with comprehensive documentation for `setInstallReferrerTimeout` method
+* Added new section: "Set Install Referrer Timeout" with usage examples
+* Updated example configurations in `branch-config.json` section
+
 ## 9.2.0
 ### 🎉 Features
 * Added optional deferred SDK initialization for iOS, allowing apps to initialize the native Branch SDK later (e.g., after obtaining user consent).

--- a/README.md
+++ b/README.md
@@ -808,10 +808,10 @@ FlutterBranchSdk.setInstallReferrerTimeout(5000);
 }
 ```
 
-Both approaches work, but configuring via `branch-config.json` is recommended as it applies the setting during SDK initialization. If you set it via Dart code, it will override the JSON configuration applied previously.
+Both approaches work, but configuring via `branch-config.json` is recommended as it applies the setting during SDK initialization. If you set it via Dart code, it will override the JSON configuration applied previously. The default for `installReferrerTimeout` is `0`, and setting it to `0` explicitly is supported and disables the timeout (`no timeout`).
 
 **Parameters:**
-- `timeoutMs` (Integer): Timeout in milliseconds. Must be >= 0. Default is 0 (no timeout).
+- `timeoutMs` (Integer): Timeout in milliseconds. Must be >= 0. Default is `0`. A value of `0` is meaningful and disables the timeout (`no timeout`).
 
 **Platform Notes:**
 - **Android**: Sets the timeout for retrieving the Install Referrer string from Google Play Services.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Supports Android, iOS and Web.
 
 | Platform | Version | History 
 | --- |---------| ---
-| Android | 5.20.+  | [Android Version History](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/releases)
+| Android | 5.21.+  | [Android Version History](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/releases)
 | iOS | 3.14.+  | [iOS Version History](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/releases)
 | Web | 2.86.+  | [Web Version History](https://github.com/BranchMetrics/web-branch-deep-linking-attribution/releases)
 
@@ -282,6 +282,7 @@ Copy and paste the following structure into your `assets/branch-config.json` fil
 *   **`useTestInstance`**: (Optional, default: `false`) Set to `true` to use the test key for debugging and testing. Set to `false` for production releases. This allows you to easily switch between environments.
 *   **`enableLogging`**: (Optional, default: `false`) Set to `true` to see detailed logs from the native Branch SDK in your device's log output (Logcat for Android, Console for iOS).
 *   **`logLevel`**: (Optional, default: `"VERBOSE"`) Controls the verbosity of logs. Valid values: `"VERBOSE"`, `"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`, `"NONE"`. Only applies when `enableLogging` is `true`. This setting takes priority over the `logLevel` parameter in `init()`.
+*   **`installReferrerTimeout`**: (Optional, default: no timeout) Sets the timeout in milliseconds for retrieving the Install Referrer string from Google Play Services. Only applicable on Android - iOS ignores this setting. Must be an integer value >= 0.
 
 > **Note:** Branch SDK logs are only available through the `FlutterBranchSdk.platformLogs` stream. They will not appear in standard console output unless you explicitly listen to this stream. See [Listening to Platform Logs](#listening-to-platform-logs) for implementation details.
 
@@ -298,7 +299,8 @@ Copy and paste the following structure into your `assets/branch-config.json` fil
   "testKey": "key_test_xxxx",
   "useTestInstance": true,
   "enableLogging": true,
-  "logLevel": "VERBOSE"
+  "logLevel": "VERBOSE",
+  "installReferrerTimeout": 5000
 }
 ```
 
@@ -308,7 +310,8 @@ Copy and paste the following structure into your `assets/branch-config.json` fil
   "testKey": "key_test_xxxx",
   "useTestInstance": true,
   "enableLogging": true,
-  "logLevel": "DEBUG"
+  "logLevel": "DEBUG",
+  "installReferrerTimeout": 5000
 }
 ```
 
@@ -318,7 +321,8 @@ Copy and paste the following structure into your `assets/branch-config.json` fil
   "liveKey": "key_live_xxxx",
   "useTestInstance": false,
   "enableLogging": true,
-  "logLevel": "ERROR"
+  "logLevel": "ERROR",
+  "installReferrerTimeout": 3000
 }
 ```
 
@@ -327,7 +331,8 @@ Copy and paste the following structure into your `assets/branch-config.json` fil
 {
   "liveKey": "key_live_xxxx",
   "useTestInstance": false,
-  "enableLogging": false
+  "enableLogging": false,
+  "installReferrerTimeout": 3000
 }
 ```
 
@@ -786,6 +791,32 @@ Add key value pairs to all requests
 ```dart
 FlutterBranchSdk.setRequestMetadata(requestMetadataKey, requestMetadataValue);
 ```
+
+### Set Install Referrer Timeout
+Provides a setting to cancel the external Install Referrer string fetch. This is useful to optimize performance on Android by limiting the time the SDK waits for the Install Referrer. Only applicable on Android - iOS ignores this setting.
+
+**Via Dart:**
+```dart
+// Set timeout to 5 seconds (5000 milliseconds)
+FlutterBranchSdk.setInstallReferrerTimeout(5000);
+```
+
+**Via branch-config.json (recommended - applied on app startup):**
+```json
+{
+  "installReferrerTimeout": 5000
+}
+```
+
+Both approaches work, but configuring via `branch-config.json` is recommended as it applies the setting during SDK initialization. If you set it via Dart code, it will override the JSON configuration applied previously.
+
+**Parameters:**
+- `timeoutMs` (Integer): Timeout in milliseconds. Must be >= 0. Default is 0 (no timeout).
+
+**Platform Notes:**
+- **Android**: Sets the timeout for retrieving the Install Referrer string from Google Play Services.
+- **iOS**: Not supported.
+- **Web**: Not supported.
 
 ### Listen to Platform Logs
 The `platformLogs` stream provides real-time log messages emitted by the native Branch SDK (iOS/Android) for debugging and monitoring purposes. This is especially useful during development to understand SDK behavior without accessing native console logs.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Copy and paste the following structure into your `assets/branch-config.json` fil
 *   **`useTestInstance`**: (Optional, default: `false`) Set to `true` to use the test key for debugging and testing. Set to `false` for production releases. This allows you to easily switch between environments.
 *   **`enableLogging`**: (Optional, default: `false`) Set to `true` to see detailed logs from the native Branch SDK in your device's log output (Logcat for Android, Console for iOS).
 *   **`logLevel`**: (Optional, default: `"VERBOSE"`) Controls the verbosity of logs. Valid values: `"VERBOSE"`, `"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`, `"NONE"`. Only applies when `enableLogging` is `true`. This setting takes priority over the `logLevel` parameter in `init()`.
-*   **`installReferrerTimeout`**: (Optional, default: no timeout) Sets the timeout in milliseconds for retrieving the Install Referrer string from Google Play Services. Only applicable on Android - iOS ignores this setting. Must be an integer value >= 0.
+*   **`installReferrerTimeout`**: (Optional, default: `0` (no timeout)) Sets the timeout in milliseconds for retrieving the Install Referrer string from Google Play Services. Only applicable on Android - iOS and Web ignore this setting. Must be an integer value >= 0.
 
 > **Note:** Branch SDK logs are only available through the `FlutterBranchSdk.platformLogs` stream. They will not appear in standard console output unless you explicitly listen to this stream. See [Listening to Platform Logs](#listening-to-platform-logs) for implementation details.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ android {
     }
 
     dependencies {
-        implementation 'io.branch.sdk.android:library:5.20.+'
+        implementation 'io.branch.sdk.android:library:5.21.+'
         implementation 'com.google.android.gms:play-services-ads-identifier:18.2.0'
         implementation 'androidx.lifecycle:lifecycle-runtime:2.9.2'
         implementation 'androidx.browser:browser:1.8.0'

--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/BranchJsonConfig.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/BranchJsonConfig.java
@@ -19,6 +19,7 @@ public class BranchJsonConfig {
     public final Boolean enableLogging;
     public final String logLevel;
     public final Boolean useTestInstance;
+    public final Integer installReferrerTimeout;
 
     public final String apiUrlAndroid;
     public final String apiUrlIOS;
@@ -33,6 +34,8 @@ public class BranchJsonConfig {
         this.enableLogging = jsonObject.has("enableLogging") && jsonObject.optBoolean("enableLogging");
         this.logLevel = jsonObject.optString("logLevel", "VERBOSE");
         this.useTestInstance = jsonObject.has("useTestInstance") && jsonObject.optBoolean("useTestInstance");
+        int timeout = jsonObject.optInt("installReferrerTimeout", -1);
+        this.installReferrerTimeout = timeout >= 0 ? timeout : null;
     }
 
     public static BranchJsonConfig loadFromFile(Context context, FlutterPlugin.FlutterPluginBinding binding) {

--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
@@ -547,7 +547,7 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
             }
         }
 
-        if (installReferrerTimeout > 0) {
+        if (installReferrerTimeout != null) {
             new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setInstallReferrerTimeout(installReferrerTimeout));
         }
 

--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
@@ -62,6 +62,7 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
     private final JSONObject snapParameters = new JSONObject();
     private final ArrayList<String> preInstallParameters = new ArrayList<>();
     private final ArrayList<String> campaingParameters = new ArrayList<>();
+    private Integer installReferrerTimeout = 0;
     private Activity activity;
     private Context context;
     private ActivityPluginBinding activityPluginBinding;
@@ -388,6 +389,9 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
             case "setRetryInterval":
                 setRetryInterval(call);
                 break;
+            case "setInstallReferrerTimeout":
+                setInstallReferrerTimeout(call);
+                break;
             case "getLastAttributedTouchData":
                 getLastAttributedTouchData(call, result);
                 break;
@@ -460,6 +464,11 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
                 }
                 LogUtils.debug(DEBUG_NAME, "Set EnableLogging and LogLevel from branch-config.json: " + branchJsonConfig.logLevel);
                 enableLoggingFromJson = true;
+            }
+
+            if (branchJsonConfig.installReferrerTimeout != null && branchJsonConfig.installReferrerTimeout >= 0) {
+                new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setInstallReferrerTimeout(branchJsonConfig.installReferrerTimeout));
+                LogUtils.debug(DEBUG_NAME, "Set installReferrerTimeout from branch-config.json: " + branchJsonConfig.installReferrerTimeout + " ms");
             }
 
             if (!branchJsonConfig.branchKey.isEmpty()) {
@@ -536,6 +545,10 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
             for (int i = 0; i < campaingParameters.size(); i++) {
                 Branch.getAutoInstance(context).setPreinstallCampaign(campaingParameters.get(i));
             }
+        }
+
+        if (installReferrerTimeout > 0) {
+            new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setInstallReferrerTimeout(installReferrerTimeout));
         }
 
         final String branchAttributionLevelString = Objects.requireNonNull(call.argument("branchAttributionLevel"));
@@ -778,6 +791,25 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
         new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setRetryInterval(value));
     }
 
+    private void setInstallReferrerTimeout(final MethodCall call) {
+        LogUtils.debug(DEBUG_NAME, "triggered setInstallReferrerTimeout");
+        if (!(call.arguments instanceof Map)) {
+            throw new IllegalArgumentException("Map argument expected");
+        }
+
+        final int timeoutMs = Objects.requireNonNull(call.argument("timeoutMs"));
+
+        if (!isInitialized) {
+            installReferrerTimeout = timeoutMs;
+            return;
+        }
+        if (timeoutMs >= 0) {
+            new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setInstallReferrerTimeout(timeoutMs));
+        } else {
+            LogUtils.debug(DEBUG_NAME, "setInstallReferrerTimeout: timeoutMs must be 0 or greater");
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private void getLastAttributedTouchData(final MethodCall call, final Result result) {
         LogUtils.debug(DEBUG_NAME, "triggered getLastAttributedTouchData");
@@ -892,6 +924,10 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
                 LogUtils.debug(DEBUG_NAME, error.getLocalizedMessage());
             }
         }
+        if (!isInitialized) {
+            return;
+        }
+
         new Handler(Looper.getMainLooper()).post(() -> Branch.getAutoInstance(context).addFacebookPartnerParameterWithName(key, value));
     }
 
@@ -909,6 +945,10 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
         final String value = Objects.requireNonNull(call.argument("value"));
         campaingParameters.add(value);
 
+        if (!isInitialized) {
+            return;
+        }
+
         new Handler(Looper.getMainLooper()).post(() -> Branch.getAutoInstance(context).setPreinstallCampaign(value));
     }
 
@@ -920,6 +960,10 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
         }
         final String value = Objects.requireNonNull(call.argument("value"));
         preInstallParameters.add(value);
+
+        if (!isInitialized) {
+            return;
+        }
 
         new Handler(Looper.getMainLooper()).post(() -> Branch.getAutoInstance(context).setPreinstallPartner(value));
     }
@@ -940,6 +984,10 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
             } catch (JSONException error) {
                 LogUtils.debug(DEBUG_NAME, error.getLocalizedMessage());
             }
+        }
+
+        if (!isInitialized) {
+            return;
         }
 
         new Handler(Looper.getMainLooper()).post(() -> Branch.getAutoInstance(context).addSnapPartnerParameterWithName(key, value));

--- a/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
+++ b/android/src/main/java/br/com/rsmarques/flutter_branch_sdk/FlutterBranchSdkPlugin.java
@@ -466,7 +466,7 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
                 enableLoggingFromJson = true;
             }
 
-            if (branchJsonConfig.installReferrerTimeout != null && branchJsonConfig.installReferrerTimeout >= 0) {
+            if (branchJsonConfig.installReferrerTimeout != null) {
                 new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setInstallReferrerTimeout(branchJsonConfig.installReferrerTimeout));
                 LogUtils.debug(DEBUG_NAME, "Set installReferrerTimeout from branch-config.json: " + branchJsonConfig.installReferrerTimeout + " ms");
             }
@@ -806,7 +806,7 @@ public class FlutterBranchSdkPlugin implements FlutterPlugin, MethodCallHandler,
         if (timeoutMs >= 0) {
             new Handler(Looper.getMainLooper()).post(() -> Branch.getInstance().setInstallReferrerTimeout(timeoutMs));
         } else {
-            LogUtils.debug(DEBUG_NAME, "setInstallReferrerTimeout: timeoutMs must be 0 or greater");
+            LogUtils.debug(DEBUG_NAME, "setInstallReferrerTimeout: timeoutMs must be 0 or greater (negative values are not allowed)");
         }
     }
 

--- a/example/assets/branch-config.json
+++ b/example/assets/branch-config.json
@@ -6,5 +6,6 @@
   "testKey": "key_test_ipQTteg11ENANDeCzSXgqdgfuycWoXYH",
   "useTestInstance": true,
   "enableLogging": true,
-  "logLevel": "VERBOSE"
+  "logLevel": "VERBOSE",
+  "installReferrerTimeout": 5000
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,9 @@ void main() async {
   FlutterBranchSdk.setAnonID('1234556');
   FlutterBranchSdk.setSDKWaitTimeForThirdPartyAPIs(2.5);
 
+  // Set Install Referrer Timeout (Android only - iOS ignores this)
+  //FlutterBranchSdk.setInstallReferrerTimeout(10000); // 10 seconds timeout
+
   //Simulate delay to started the app
   //await Future.delayed(const Duration(seconds: 10));
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "9.2.0"
+    version: "9.3.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -147,10 +147,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -232,10 +232,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -61,7 +61,7 @@ flutter:
   #   - images/a_dot_ham.jpeg
   assets:
     - assets/images/branch_logo.jpeg
-    #- assets/branch-config.json
+    - assets/branch-config.json
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware

--- a/ios/flutter_branch_sdk/sources/flutter_branch_sdk/BranchJsonConfigFlutter.swift
+++ b/ios/flutter_branch_sdk/sources/flutter_branch_sdk/BranchJsonConfigFlutter.swift
@@ -11,6 +11,7 @@ struct BranchJsonConfigFlutter: Codable {
     let enableLogging: Bool?
     let logLevel: String?
     let useTestInstance: Bool?
+    let installReferrerTimeout: Int?
 
     static func loadFromFile(registrar: FlutterPluginRegistrar) -> BranchJsonConfigFlutter? {
         let assetKey = registrar.lookupKey(forAsset: "assets/branch-config.json")

--- a/ios/flutter_branch_sdk/sources/flutter_branch_sdk/FlutterBranchSdkPlugin.swift
+++ b/ios/flutter_branch_sdk/sources/flutter_branch_sdk/FlutterBranchSdkPlugin.swift
@@ -946,7 +946,13 @@ public class FlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStreamHandl
     }
     
     private func setInstallReferrerTimeout(call: FlutterMethodCall) {
-        LogUtils.debug(message: "setInstallReferrerTimeout called, but not applicable for iOS SDK version.")
+        guard let args = call.arguments as? [String: Any],
+              let timeoutMs = args["timeoutMs"] as? Int else {
+            LogUtils.debug(message: "Invalid arguments provided for setInstallReferrerTimeout")
+            return
+        }
+        // Only log - not applicable for iOS SDK
+        LogUtils.debug(message: "setInstallReferrerTimeout called with value \(timeoutMs)ms, but not applicable for iOS SDK version.")
     }
     
     private func getQRCode(call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/ios/flutter_branch_sdk/sources/flutter_branch_sdk/FlutterBranchSdkPlugin.swift
+++ b/ios/flutter_branch_sdk/sources/flutter_branch_sdk/FlutterBranchSdkPlugin.swift
@@ -14,7 +14,7 @@ let EVENT_CHANNEL = "flutter_branch_sdk/event";
 let LOG_CHANNEL = "flutter_branch_sdk/logStream";
 let ERROR_CODE = "FLUTTER_BRANCH_SDK_ERROR";
 let PLUGIN_NAME = "Flutter";
-let PLUGIN_VERSION = "9.2.0";
+let PLUGIN_VERSION = "9.3.0";
 let COCOA_POD_NAME = "org.cocoapods.flutter-branch-sdk";
 
 //---------------------------------------------------------------------------------------------
@@ -325,6 +325,11 @@ public class FlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStreamHandl
                 self.enableLoggingFromJson = true
                 LogUtils.debug(message: "Set enableLogging and logLevel from branch-config.json: \(logLevelStr)")
             }
+
+            // Set installReferrerTimeout if configured
+            if let installReferrerTimeout = branchJsonConfig.installReferrerTimeout, installReferrerTimeout >= 0 {
+                LogUtils.debug(message: "setInstallReferrerTimeout called with value \(installReferrerTimeout)ms, but not directly applicable for iOS SDK version.")
+            }
         } else {
             LogUtils.debug(message: "No branch-config.json found, using default configuration")
         }
@@ -478,6 +483,9 @@ public class FlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStreamHandl
             break
         case "setRetryInterval":
             setRetryInterval(call: call)
+            break
+        case "setInstallReferrerTimeout":
+            setInstallReferrerTimeout(call: call)
             break
         case "setTimeout":
             setTimeout(call: call)
@@ -935,6 +943,10 @@ public class FlutterBranchSdkPlugin: NSObject, FlutterPlugin, FlutterStreamHandl
         DispatchQueue.main.async {
             Branch.getInstance().setRetryInterval(TimeInterval(retryInterval))
         }
+    }
+    
+    private func setInstallReferrerTimeout(call: FlutterMethodCall) {
+        LogUtils.debug(message: "setInstallReferrerTimeout called, but not applicable for iOS SDK version.")
     }
     
     private func getQRCode(call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/lib/src/flutter_branch_sdk.dart
+++ b/lib/src/flutter_branch_sdk.dart
@@ -22,9 +22,16 @@ class FlutterBranchSdk {
   ///   - `BranchAttributionLevel.NONE`: No Attribution - No Analytics (GDPR, CCPA)
   ///
 
-  static Future<void> init({bool enableLogging = false, BranchLogLevel logLevel = BranchLogLevel.VERBOSE, BranchAttributionLevel? branchAttributionLevel}) async {
-    await FlutterBranchSdkPlatform.instance
-        .init(enableLogging: enableLogging, logLevel: logLevel, branchAttributionLevel: branchAttributionLevel);
+  static Future<void> init({
+    bool enableLogging = false,
+    BranchLogLevel logLevel = BranchLogLevel.VERBOSE,
+    BranchAttributionLevel? branchAttributionLevel,
+  }) async {
+    await FlutterBranchSdkPlatform.instance.init(
+      enableLogging: enableLogging,
+      logLevel: logLevel,
+      branchAttributionLevel: branchAttributionLevel,
+    );
   }
 
   ///Identifies the current user to the Branch API by supplying a unique identifier as a userId value
@@ -64,24 +71,28 @@ class FlutterBranchSdk {
   }
 
   ///Creates a short url for the BUO
-  static Future<BranchResponse> getShortUrl(
-      {required BranchUniversalObject buo, required BranchLinkProperties linkProperties}) async {
+  static Future<BranchResponse> getShortUrl({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+  }) async {
     return FlutterBranchSdkPlatform.instance.getShortUrl(buo: buo, linkProperties: linkProperties);
   }
 
   ///Showing a Share Sheet
-  static Future<BranchResponse> showShareSheet(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required String messageText,
-      String androidMessageTitle = '',
-      String androidSharingTitle = ''}) async {
+  static Future<BranchResponse> showShareSheet({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required String messageText,
+    String androidMessageTitle = '',
+    String androidSharingTitle = '',
+  }) async {
     return FlutterBranchSdkPlatform.instance.showShareSheet(
-        buo: buo,
-        linkProperties: linkProperties,
-        messageText: messageText,
-        androidMessageTitle: androidMessageTitle,
-        androidSharingTitle: androidSharingTitle);
+      buo: buo,
+      linkProperties: linkProperties,
+      messageText: messageText,
+      androidMessageTitle: androidMessageTitle,
+      androidSharingTitle: androidSharingTitle,
+    );
   }
 
   ///Logs this BranchEvent to Branch for tracking and analytics
@@ -172,36 +183,49 @@ class FlutterBranchSdk {
   }
 
   ///Creates a Branch QR Code image. Returns the QR code as Uint8List.
-  static Future<BranchResponse> getQRCodeAsData(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required BranchQrCode qrCode}) async {
-    return FlutterBranchSdkPlatform.instance
-        .getQRCodeAsData(buo: buo, linkProperties: linkProperties, qrCodeSettings: qrCode);
+  static Future<BranchResponse> getQRCodeAsData({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required BranchQrCode qrCode,
+  }) async {
+    return FlutterBranchSdkPlatform.instance.getQRCodeAsData(
+      buo: buo,
+      linkProperties: linkProperties,
+      qrCodeSettings: qrCode,
+    );
   }
 
   ///Creates a Branch QR Code image. Returns the QR code as a Image.
-  static Future<BranchResponse> getQRCodeAsImage(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required BranchQrCode qrCode}) async {
-    return FlutterBranchSdkPlatform.instance
-        .getQRCodeAsImage(buo: buo, linkProperties: linkProperties, qrCodeSettings: qrCode);
+  static Future<BranchResponse> getQRCodeAsImage({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required BranchQrCode qrCode,
+  }) async {
+    return FlutterBranchSdkPlatform.instance.getQRCodeAsImage(
+      buo: buo,
+      linkProperties: linkProperties,
+      qrCodeSettings: qrCode,
+    );
   }
 
   ///Share with LPLinkMetadata on iOS
-  static void shareWithLPLinkMetadata(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required Uint8List icon,
-      required String title}) {
+  static void shareWithLPLinkMetadata({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required Uint8List icon,
+    required String title,
+  }) {
     final Map<String, dynamic> params = {};
     params['buo'] = buo.toMap();
     params['lp'] = linkProperties.toMap();
     params['title'] = title;
 
-    FlutterBranchSdkPlatform.instance
-        .shareWithLPLinkMetadata(buo: buo, linkProperties: linkProperties, icon: icon, title: title);
+    FlutterBranchSdkPlatform.instance.shareWithLPLinkMetadata(
+      buo: buo,
+      linkProperties: linkProperties,
+      icon: icon,
+      title: title,
+    );
   }
 
   ///Have Branch end the current deep link session and start a new session with the provided URL.
@@ -233,7 +257,6 @@ class FlutterBranchSdk {
 
   /// Provides a setting to cancel the external Install Referrer string fetch.
   /// Default is 0 milliseconds, no timeout.
-  /// For Android only - iOS ignores this call.
   static void setInstallReferrerTimeout(int timeoutMs) {
     FlutterBranchSdkPlatform.instance.setInstallReferrerTimeout(timeoutMs);
   }
@@ -248,12 +271,16 @@ class FlutterBranchSdk {
   /// [eeaRegion] `true` If European regulations, including the DMA, apply to this user and conversion.
   /// [adPersonalizationConsent] `true` If End user has granted/denied ads personalization consent.
   /// [adUserDataUsageConsent] `true If User has granted/denied consent for 3P transmission of user level data for ads.
-  static void setDMAParamsForEEA(
-      {required bool eeaRegion, required bool adPersonalizationConsent, required bool adUserDataUsageConsent}) {
+  static void setDMAParamsForEEA({
+    required bool eeaRegion,
+    required bool adPersonalizationConsent,
+    required bool adUserDataUsageConsent,
+  }) {
     FlutterBranchSdkPlatform.instance.setDMAParamsForEEA(
-        eeaRegion: eeaRegion,
-        adPersonalizationConsent: adPersonalizationConsent,
-        adUserDataUsageConsent: adUserDataUsageConsent);
+      eeaRegion: eeaRegion,
+      adPersonalizationConsent: adPersonalizationConsent,
+      adUserDataUsageConsent: adUserDataUsageConsent,
+    );
   }
 
   /// Sets the consumer protection attribution level.

--- a/lib/src/flutter_branch_sdk.dart
+++ b/lib/src/flutter_branch_sdk.dart
@@ -231,6 +231,13 @@ class FlutterBranchSdk {
     FlutterBranchSdkPlatform.instance.setPreinstallPartner(value);
   }
 
+  /// Provides a setting to cancel the external Install Referrer string fetch.
+  /// Default is 0 milliseconds, no timeout.
+  /// For Android only - iOS ignores this call.
+  static void setInstallReferrerTimeout(int timeoutMs) {
+    FlutterBranchSdkPlatform.instance.setInstallReferrerTimeout(timeoutMs);
+  }
+
   ///Add a Partner Parameter for Snap.
   ///Once set, this parameter is attached to installs, opens and events until cleared or the app restarts.
   static void addSnapPartnerParameter({required String key, required String value}) {

--- a/lib/src/flutter_branch_sdk_method_channel.dart
+++ b/lib/src/flutter_branch_sdk_method_channel.dart
@@ -315,7 +315,7 @@ class FlutterBranchSdkMethodChannel implements FlutterBranchSdkPlatform {
   @override
   void setInstallReferrerTimeout(int timeoutMs) {
     if (timeoutMs < 0) {
-      throw ArgumentError('timeoutMs must be >= 0');
+      throw ArgumentError('timeoutMs must be >= 0. Negative values are not allowed');
     }
     _messageChannel.invokeMethod('setInstallReferrerTimeout', {'timeoutMs': timeoutMs});
   }

--- a/lib/src/flutter_branch_sdk_method_channel.dart
+++ b/lib/src/flutter_branch_sdk_method_channel.dart
@@ -313,6 +313,14 @@ class FlutterBranchSdkMethodChannel implements FlutterBranchSdkPlatform {
   }
 
   @override
+  void setInstallReferrerTimeout(int timeoutMs) {
+    if (timeoutMs < 0) {
+      throw ArgumentError('timeoutMs must be >= 0');
+    }
+    _messageChannel.invokeMethod('setInstallReferrerTimeout', {'timeoutMs': timeoutMs});
+  }
+
+  @override
   void setTimeout(int timeout) {
     _ensureInitialized('setTimeout');
     _messageChannel.invokeMethod('setTimeout', {'timeout': timeout});

--- a/lib/src/flutter_branch_sdk_platform_interface.dart
+++ b/lib/src/flutter_branch_sdk_platform_interface.dart
@@ -50,7 +50,11 @@ abstract class FlutterBranchSdkPlatform extends PlatformInterface {
   ///   - `BranchAttributionLevel.NONE`: No Attribution - No Analytics (GDPR, CCPA)
   ///
 
-  Future<void> init({bool enableLogging = false, BranchLogLevel logLevel = BranchLogLevel.VERBOSE, BranchAttributionLevel? branchAttributionLevel}) async {
+  Future<void> init({
+    bool enableLogging = false,
+    BranchLogLevel logLevel = BranchLogLevel.VERBOSE,
+    BranchAttributionLevel? branchAttributionLevel,
+  }) async {
     throw UnimplementedError('init has not been implemented');
   }
 
@@ -91,18 +95,21 @@ abstract class FlutterBranchSdkPlatform extends PlatformInterface {
   }
 
   ///Creates a short url for the BUO
-  Future<BranchResponse> getShortUrl(
-      {required BranchUniversalObject buo, required BranchLinkProperties linkProperties}) async {
+  Future<BranchResponse> getShortUrl({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+  }) async {
     throw UnimplementedError('getShortUrl has not been implemented');
   }
 
   ///Showing a Share Sheet
-  Future<BranchResponse> showShareSheet(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required String messageText,
-      String androidMessageTitle = '',
-      String androidSharingTitle = ''}) async {
+  Future<BranchResponse> showShareSheet({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required String messageText,
+    String androidMessageTitle = '',
+    String androidSharingTitle = '',
+  }) async {
     throw UnimplementedError('showShareSheet has not been implemented');
   }
 
@@ -194,27 +201,30 @@ abstract class FlutterBranchSdkPlatform extends PlatformInterface {
   }
 
   ///Creates a Branch QR Code image. Returns the QR code as Uint8List.
-  Future<BranchResponse> getQRCodeAsData(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required BranchQrCode qrCodeSettings}) async {
+  Future<BranchResponse> getQRCodeAsData({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required BranchQrCode qrCodeSettings,
+  }) async {
     throw UnimplementedError('getQRCodeAsData has not been implemented');
   }
 
   ///Creates a Branch QR Code image. Returns the QR code as a Image.
-  Future<BranchResponse> getQRCodeAsImage(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required BranchQrCode qrCodeSettings}) async {
+  Future<BranchResponse> getQRCodeAsImage({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required BranchQrCode qrCodeSettings,
+  }) async {
     throw UnimplementedError('getQRCodeAsImage has not been implemented');
   }
 
   ///Showing a Share Sheet with LPLinkMetadata in iOS
-  Future<void> shareWithLPLinkMetadata(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required Uint8List icon,
-      required String title}) async {
+  Future<void> shareWithLPLinkMetadata({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required Uint8List icon,
+    required String title,
+  }) async {
     throw UnimplementedError('shareWithLPLinkMetadata has not been implemented');
   }
 
@@ -235,7 +245,6 @@ abstract class FlutterBranchSdkPlatform extends PlatformInterface {
 
   /// Provides a setting to cancel the external Install Referrer string fetch.
   /// Default is 0 milliseconds, no timeout.
-  /// For Android only - iOS ignores this call.
   /// [timeoutMs] The timeout in milliseconds. Must be >= 0.
   void setInstallReferrerTimeout(int timeoutMs) {
     throw UnimplementedError('setInstallReferrerTimeout has not been implemented');
@@ -263,8 +272,11 @@ abstract class FlutterBranchSdkPlatform extends PlatformInterface {
   /// [eeaRegion] `true` If European regulations, including the DMA, apply to this user and conversion.
   /// [adPersonalizationConsent] `true` If End user has granted/denied ads personalization consent.
   /// [adUserDataUsageConsent] `true If User has granted/denied consent for 3P transmission of user level data for ads.
-  void setDMAParamsForEEA(
-      {required bool eeaRegion, required bool adPersonalizationConsent, required bool adUserDataUsageConsent}) {
+  void setDMAParamsForEEA({
+    required bool eeaRegion,
+    required bool adPersonalizationConsent,
+    required bool adUserDataUsageConsent,
+  }) {
     throw UnimplementedError('setDMAParamsForEEA has not been implemented');
   }
 

--- a/lib/src/flutter_branch_sdk_platform_interface.dart
+++ b/lib/src/flutter_branch_sdk_platform_interface.dart
@@ -233,6 +233,14 @@ abstract class FlutterBranchSdkPlatform extends PlatformInterface {
     throw UnimplementedError('setPreinstallPartner has not been implemented');
   }
 
+  /// Provides a setting to cancel the external Install Referrer string fetch.
+  /// Default is 0 milliseconds, no timeout.
+  /// For Android only - iOS ignores this call.
+  /// [timeoutMs] The timeout in milliseconds. Must be >= 0.
+  void setInstallReferrerTimeout(int timeoutMs) {
+    throw UnimplementedError('setInstallReferrerTimeout has not been implemented');
+  }
+
   /// Add a Partner Parameter for Facebook.
   /// Once set, this parameter is attached to installs, opens and events until cleared or the app restarts.
   /// See Facebook's documentation for details on valid parameters

--- a/lib/src/flutter_branch_sdk_web.dart
+++ b/lib/src/flutter_branch_sdk_web.dart
@@ -47,7 +47,11 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
   ///
 
   @override
-  Future<void> init({bool enableLogging = false, BranchLogLevel logLevel = BranchLogLevel.VERBOSE, BranchAttributionLevel? branchAttributionLevel}) async {
+  Future<void> init({
+    bool enableLogging = false,
+    BranchLogLevel logLevel = BranchLogLevel.VERBOSE,
+    BranchAttributionLevel? branchAttributionLevel,
+  }) async {
     debugPrint('For web, start the SDK in index.html');
   }
 
@@ -74,18 +78,20 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
     final Completer<Map<dynamic, dynamic>> response = Completer();
 
     try {
-      BranchJS.data((JSAny? err, JSAny? data) {
-        if (err == null) {
-          if (data != null) {
-            final responseData = Map<dynamic, dynamic>.from(_jsObjectToDartObject(data));
-            response.complete(responseData['data_parsed'] ?? {});
+      BranchJS.data(
+        (JSAny? err, JSAny? data) {
+          if (err == null) {
+            if (data != null) {
+              final responseData = Map<dynamic, dynamic>.from(_jsObjectToDartObject(data));
+              response.complete(responseData['data_parsed'] ?? {});
+            } else {
+              response.complete({});
+            }
           } else {
-            response.complete({});
+            response.completeError(err);
           }
-        } else {
-          response.completeError(err);
-        }
-      }.toJS);
+        }.toJS,
+      );
     } catch (e) {
       debugPrint('getLatestReferringParams() error: ${e.toString()}');
       response.completeError(e);
@@ -99,18 +105,20 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
     final Completer<Map<dynamic, dynamic>> response = Completer<Map<dynamic, dynamic>>();
 
     try {
-      BranchJS.first((JSAny? err, JSAny? data) {
-        if (err == null) {
-          if (data != null) {
-            final responseData = Map<dynamic, dynamic>.from(_jsObjectToDartObject(data));
-            response.complete(responseData['data_parsed'] ?? {});
+      BranchJS.first(
+        (JSAny? err, JSAny? data) {
+          if (err == null) {
+            if (data != null) {
+              final responseData = Map<dynamic, dynamic>.from(_jsObjectToDartObject(data));
+              response.complete(responseData['data_parsed'] ?? {});
+            } else {
+              response.complete({});
+            }
           } else {
-            response.complete({});
+            response.completeError(err);
           }
-        } else {
-          response.completeError(err);
-        }
-      }.toJS);
+        }.toJS,
+      );
     } catch (e) {
       debugPrint('getFirstReferringParams() error: ${e.toString()}');
       response.completeError(e);
@@ -123,12 +131,13 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
   void setIdentity(String userId) {
     try {
       BranchJS.setIdentity(
-          userId,
-          (JSAny? error, JSAny? data) {
-            if (error == null) {
-              _userIdentified = true;
-            }
-          }.toJS);
+        userId,
+        (JSAny? error, JSAny? data) {
+          if (error == null) {
+            _userIdentified = true;
+          }
+        }.toJS,
+      );
     } catch (e) {
       debugPrint('setIdentity() error: ${e.toString()}');
     }
@@ -138,11 +147,13 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
   @override
   void logout() {
     try {
-      BranchJS.logout((JSAny? error) {
-        if (error == null) {
-          _userIdentified = false;
-        }
-      }.toJS);
+      BranchJS.logout(
+        (JSAny? error) {
+          if (error == null) {
+            _userIdentified = false;
+          }
+        }.toJS,
+      );
     } catch (e) {
       debugPrint('logout() error: ${e.toString()}');
     }
@@ -150,8 +161,10 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
 
   ///Creates a short url for the BUO
   @override
-  Future<BranchResponse> getShortUrl(
-      {required BranchUniversalObject buo, required BranchLinkProperties linkProperties}) async {
+  Future<BranchResponse> getShortUrl({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+  }) async {
     final Map<String, dynamic> data = buo.toMap();
     linkProperties.getControlParams().forEach((key, value) {
       data[key] = value;
@@ -162,21 +175,22 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
 
     try {
       BranchJS.link(
-          _dartObjectToJsObject(linkData),
-          (JSAny? err, String url) {
-            if (err == null) {
-              responseCompleter.complete(BranchResponse.success(result: url));
+        _dartObjectToJsObject(linkData),
+        (JSAny? err, String url) {
+          if (err == null) {
+            responseCompleter.complete(BranchResponse.success(result: url));
+          } else {
+            final dynamic jsError = err;
+            String errorMessage;
+            if (jsError is String) {
+              errorMessage = jsError;
             } else {
-              final dynamic jsError = err;
-              String errorMessage;
-              if (jsError is String) {
-                errorMessage = jsError;
-              } else {
-                errorMessage = jsError.toString(); // Como fallback, converte para string
-              }
-              responseCompleter.complete(BranchResponse.error(errorCode: '-1', errorMessage: errorMessage));
+                errorMessage = jsError.toString();
             }
-          }.toJS);
+            responseCompleter.complete(BranchResponse.error(errorCode: '-1', errorMessage: errorMessage));
+          }
+        }.toJS,
+      );
     } catch (e) {
       debugPrint('getShortUrl() error: ${e.toString()}');
       responseCompleter.completeError(BranchResponse.error(errorCode: '-1', errorMessage: 'getShortUrl() error'));
@@ -186,17 +200,19 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
 
   ///Showing a Share Sheet - Implemented via navigator share if available, otherwise browser prompt.
   @override
-  Future<BranchResponse> showShareSheet(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required String messageText,
-      String androidMessageTitle = '',
-      String androidSharingTitle = ''}) async {
+  Future<BranchResponse> showShareSheet({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required String messageText,
+    String androidMessageTitle = '',
+    String androidSharingTitle = '',
+  }) async {
     final BranchResponse response = await getShortUrl(buo: buo, linkProperties: linkProperties);
     if (response.success) {
       try {
-        await navigatorShare(_dartObjectToJsObject({'title': messageText, 'text': buo.title, 'url': response.result}))
-            .toDart;
+        await navigatorShare(
+          _dartObjectToJsObject({'title': messageText, 'text': buo.title, 'url': response.result}),
+        ).toDart;
       } catch (e) {
         browserPrompt(messageText, response.result);
       }
@@ -215,7 +231,11 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
     try {
       if (branchEvent.alias.isNotEmpty) {
         BranchJS.logEvent(
-            branchEvent.eventName, _dartObjectToJsObject(branchEvent.toMap()), contentItems.toJS, branchEvent.alias);
+          branchEvent.eventName,
+          _dartObjectToJsObject(branchEvent.toMap()),
+          contentItems.toJS,
+          branchEvent.alias,
+        );
       } else {
         BranchJS.logEvent(branchEvent.eventName, _dartObjectToJsObject(branchEvent.toMap()), contentItems.toJS);
       }
@@ -353,32 +373,35 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
 
     try {
       BranchJS.lastAttributedTouchData(
-          attributionWindow?.toJS,
-          (JSAny? err, JSAny? data) {
-            if (err == null) {
-              if (data != null) {
-                responseCompleter.complete(BranchResponse.success(result: _jsObjectToDartObject(data)));
-              } else {
-                responseCompleter.complete(BranchResponse.success(result: {}));
-              }
+        attributionWindow?.toJS,
+        (JSAny? err, JSAny? data) {
+          if (err == null) {
+            if (data != null) {
+              responseCompleter.complete(BranchResponse.success(result: _jsObjectToDartObject(data)));
             } else {
-              responseCompleter.complete(BranchResponse.error(errorCode: '999', errorMessage: err.toString()));
+              responseCompleter.complete(BranchResponse.success(result: {}));
             }
-          }.toJS);
+          } else {
+            responseCompleter.complete(BranchResponse.error(errorCode: '999', errorMessage: err.toString()));
+          }
+        }.toJS,
+      );
     } catch (e) {
       debugPrint('getLastAttributedTouchData() error: ${e.toString()}');
-      responseCompleter
-          .complete(BranchResponse.error(errorCode: '-1', errorMessage: 'getLastAttributedTouchData() error'));
+      responseCompleter.complete(
+        BranchResponse.error(errorCode: '-1', errorMessage: 'getLastAttributedTouchData() error'),
+      );
     }
     return responseCompleter.future;
   }
 
   ///Creates a Branch QR Code image. Returns the QR code as Uint8List.
   @override
-  Future<BranchResponse> getQRCodeAsData(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required BranchQrCode qrCodeSettings}) async {
+  Future<BranchResponse> getQRCodeAsData({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required BranchQrCode qrCodeSettings,
+  }) async {
     final Completer<BranchResponse> responseCompleter = Completer();
 
     final Map<String, dynamic> data = buo.toMap();
@@ -390,40 +413,43 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
 
     try {
       BranchJS.qrCode(
-          _dartObjectToJsObject(linkData),
-          _dartObjectToJsObject(qrCodeSettings.toMap()),
-          (JSAny? err, QrCodeData? qrCode) {
-            if (err == null) {
-              if (qrCode != null) {
-                responseCompleter.complete(BranchResponse.success(result: qrCode.rawBuffer.toDart.asUint8List()));
-              } else {
-                responseCompleter.complete(BranchResponse.error(errorCode: '-1', errorMessage: 'Qrcode generate error'));
-              }
+        _dartObjectToJsObject(linkData),
+        _dartObjectToJsObject(qrCodeSettings.toMap()),
+        (JSAny? err, QrCodeData? qrCode) {
+          if (err == null) {
+            if (qrCode != null) {
+              responseCompleter.complete(BranchResponse.success(result: qrCode.rawBuffer.toDart.asUint8List()));
             } else {
-              responseCompleter.complete(BranchResponse.error(errorCode: '-1', errorMessage: err.toString()));
+              responseCompleter.complete(BranchResponse.error(errorCode: '-1', errorMessage: 'Qrcode generate error'));
             }
-          }.toJS);
+          } else {
+            responseCompleter.complete(BranchResponse.error(errorCode: '-1', errorMessage: err.toString()));
+          }
+        }.toJS,
+      );
     } catch (e) {
-      responseCompleter
-          .complete(BranchResponse.error(errorCode: '-1', errorMessage: 'qrCode generate error ${e.toString()}'));
+      responseCompleter.complete(
+        BranchResponse.error(errorCode: '-1', errorMessage: 'qrCode generate error ${e.toString()}'),
+      );
     }
     return responseCompleter.future;
   }
 
   ///Creates a Branch QR Code image. Returns the QR code as a Image.
   @override
-  Future<BranchResponse> getQRCodeAsImage(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required BranchQrCode qrCodeSettings}) async {
+  Future<BranchResponse> getQRCodeAsImage({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required BranchQrCode qrCodeSettings,
+  }) async {
     try {
-      final BranchResponse response =
-          await getQRCodeAsData(buo: buo, linkProperties: linkProperties, qrCodeSettings: qrCodeSettings);
+      final BranchResponse response = await getQRCodeAsData(
+        buo: buo,
+        linkProperties: linkProperties,
+        qrCodeSettings: qrCodeSettings,
+      );
       if (response.success) {
-        return BranchResponse.success(
-            result: Image.memory(
-          response.result,
-        ));
+        return BranchResponse.success(result: Image.memory(response.result));
       } else {
         return BranchResponse.error(errorCode: response.errorCode, errorMessage: response.errorMessage);
       }
@@ -433,11 +459,12 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
   }
 
   @override
-  Future<void> shareWithLPLinkMetadata(
-      {required BranchUniversalObject buo,
-      required BranchLinkProperties linkProperties,
-      required Uint8List icon,
-      required String title}) async {
+  Future<void> shareWithLPLinkMetadata({
+    required BranchUniversalObject buo,
+    required BranchLinkProperties linkProperties,
+    required Uint8List icon,
+    required String title,
+  }) async {
     try {
       showShareSheet(buo: buo, linkProperties: linkProperties, messageText: title);
     } catch (error) {
@@ -483,7 +510,6 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
 
   /// Provides a setting to cancel the external Install Referrer string fetch.
   /// Default is 0 milliseconds, no timeout.
-  /// For Android only - iOS ignores this call.
   @override
   void setInstallReferrerTimeout(int timeoutMs) {
     debugPrint('setInstallReferrerTimeout() Not supported by Branch JS SDK');
@@ -505,8 +531,11 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
   /// [adPersonalizationConsent] `true` If End user has granted/denied ads personalization consent.
   /// [adUserDataUsageConsent] `true If User has granted/denied consent for 3P transmission of user level data for ads.
   @override
-  void setDMAParamsForEEA(
-      {required bool eeaRegion, required bool adPersonalizationConsent, required bool adUserDataUsageConsent}) {
+  void setDMAParamsForEEA({
+    required bool eeaRegion,
+    required bool adPersonalizationConsent,
+    required bool adUserDataUsageConsent,
+  }) {
     try {
       BranchJS.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
     } catch (e) {
@@ -540,6 +569,8 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
   /// [String] format for unified visibility in the Flutter debug console.  @override
   @override
   Stream<String> get platformLogs {
-    return Stream.value('⚠️ Platform logs are not supported on Web. This feature is only available on iOS and Android platforms.');
+    return Stream.value(
+      '⚠️ Platform logs are not supported on Web. This feature is only available on iOS and Android platforms.',
+    );
   }
 }

--- a/lib/src/flutter_branch_sdk_web.dart
+++ b/lib/src/flutter_branch_sdk_web.dart
@@ -481,6 +481,14 @@ class FlutterBranchSdkWeb extends FlutterBranchSdkPlatform {
     debugPrint('setPreinstallPartner() Not supported by Branch JS SDK');
   }
 
+  /// Provides a setting to cancel the external Install Referrer string fetch.
+  /// Default is 0 milliseconds, no timeout.
+  /// For Android only - iOS ignores this call.
+  @override
+  void setInstallReferrerTimeout(int timeoutMs) {
+    debugPrint('setInstallReferrerTimeout() Not supported by Branch JS SDK');
+  }
+
   ///Add a Partner Parameter for Snap.
   ///Once set, this parameter is attached to installs, opens and events until cleared or the app restarts.
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -108,10 +108,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -193,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_branch_sdk
 description: "Flutter Plugin for create deep link using Brach SDK (https://branch.io). This plugin provides a cross-platform (iOS, Android, Web)."
-version: 9.2.0
+version: 9.3.0
 repository: https://github.com/RodrigoSMarques/flutter_branch_sdk
 
 environment:


### PR DESCRIPTION
### 🔧 Native SDK Updates
* Updated included Branch Android SDK to 5.21.0 - [Android Version History](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/releases)

### 🎉 Features
* New Method: `setInstallReferrerTimeout` - Provides a setting to cancel the external Install Referrer string fetch. This is useful to optimize performance on Android by limiting the time the SDK waits for the Install Referrer. Only applicable on Android - iOS ignores this setting.
* Added support for `installReferrerTimeout` configuration key in `branch-config.json`. This allows you to set the Install Referrer timeout during app initialization without code changes.
  - Configuration example: `"installReferrerTimeout": 5000` (in milliseconds)
  - See `README.md` for full documentation

### 📖 Documentation
* Updated `README.md` with comprehensive documentation for `setInstallReferrerTimeout` method
* Added new section: "Set Install Referrer Timeout" with usage examples
* Updated example configurations in `branch-config.json` section